### PR TITLE
Remove unused particiption parameter from node registration

### DIFF
--- a/flsim/runner.py
+++ b/flsim/runner.py
@@ -81,7 +81,6 @@ class FLRunner:
                     n.cfg.node_id,
                     stake=getattr(n, "stake", 100.0),
                     reputation=getattr(n, "reputation", 10.0),
-                    particiption=n.key_pair.participation_key,
                 )
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- Remove incorrect `particiption` keyword from `register_node` call in `FLRunner.run`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c8291db14832f855a92d63de5003b