### PR TITLE
Fix node registration in runner

### DIFF
--- a/flsim/runner.py
+++ b/flsim/runner.py
@@ -81,7 +81,6 @@ class FLRunner:
                     n.cfg.node_id,
                     stake=getattr(n, "stake", 100.0),
                     reputation=getattr(n, "reputation", 10.0),
-                    particiption=n.key_pair.participation_key,
                 )
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- fix runner failing to register nodes by removing invalid `particiption` argument

## Testing
- `python -m py_compile flsim/runner.py`
- `python - <<'PY'
from flsim.storage import ContractSim
class Dummy:
    def __init__(self, node_id, stake=100.0, reputation=10.0):
        class Cfg:
            pass
        self.cfg = Cfg()
        self.cfg.node_id = node_id
        self.stake = stake
        self.reputation = reputation
c = ContractSim()
d = Dummy(5)
try:
    c.register_node(
        d.cfg.node_id,
        stake=getattr(d, 'stake', 100.0),
        reputation=getattr(d, 'reputation', 10.0),
    )
    print('nodes', c.nodes)
except Exception as e:
    print('error', e)
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_689c8061949c832fad6bc3838c026c43