### PR TITLE
feat: persist client model updates for inspection

### DIFF
--- a/flsim/node.py
+++ b/flsim/node.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, Tuple, List, Optional
 import math
+import os
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -91,10 +92,14 @@ class LocalNode:
 
         model_cid = self.ipfs.save(update_obj)
         metrics_cid = self.ipfs.save({"loss": rep_loss, "acc": rep_acc, "samples": self.num_samples})
-        
+
         # Optional: save update *.pt locally for inspection
-        # if self.save_updates:
-        #     fname = os.path.join(self.save_dir, "updates", f"round_{round_idx}_node_{self.cfg.node_id}_{update_type}.pt")
-        #     torch.save(update_obj, fname)
+        if self.save_updates:
+            fname = os.path.join(
+                self.save_dir,
+                "updates",
+                f"round_{round_idx}_node_{self.cfg.node_id}_{update_type}.pt",
+            )
+            torch.save(update_obj, fname)
         self.contract.submit_model(round_idx, self.cfg.node_id, model_cid, metrics_cid, update_type)
         return rep_loss, rep_acc, update_type, model_cid, metrics_cid


### PR DESCRIPTION
## Summary
- allow `LocalNode` to optionally write its model update each round
- group client submissions by update type so the aggregator evaluates each against the previous global state
- store each round's base model state for later reconstruction alongside client deltas

## Testing
- `python run_experiment.py --exp testexp --rounds 1 --nodes 1 --epochs 1 --batch-size 8 --save-updates --samples-per-client 16 --alpha 0.5 --partitioner dirichlet` *(fails: ModuleNotFoundError: No module named 'torchvision')*
- `pip install torchvision -q` *(fails: Could not find a version that satisfies the requirement torchvision; Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile flsim/aggregation/aggregator.py flsim/node.py flsim/eval.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf46d1798832f99b137d303767902