### PR TITLE
Add incentive metrics visualization notebook

### DIFF
--- a/visualization/incentive_trends.ipynb
+++ b/visualization/incentive_trends.ipynb
@@ -1,0 +1,76 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Reputation, Stake, Reward and Balance Trends\n",
+        "\n",
+        "This notebook visualizes the reputation, stake, reward, and balance for each node over training rounds. It selects the latest run log and plots each metric per node."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import glob",
+        "import pandas as pd",
+        "import matplotlib.pyplot as plt",
+        "%matplotlib inline"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Select the most recent run log",
+        "dirs = sorted(glob.glob('../runs/benign/*'))",
+        "log_file = f'{dirs[-1]}/fl_log.csv'",
+        "log_file"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Load the log data",
+        "df = pd.read_csv(log_file)",
+        "df.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Plot trends for each metric",
+        "metrics = ['reputation', 'stake', 'reward', 'balance']",
+        "for metric in metrics:",
+        "    pivot = df.pivot(index='round', columns='node_id', values=metric)",
+        "    ax = pivot.plot(title=f'{metric} over rounds', legend=True)",
+        "    ax.set_xlabel('round')",
+        "    ax.set_ylabel(metric)",
+        "    plt.show()"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- add incentive_trends notebook to visualize reputation, stake, reward, and balance evolution from run logs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e470d6908832fb5a2fb88d3a6c4f7