### PR TITLE
Integrate FLAME aggregation and refine rewards

### DIFF
--- a/flsim/contracts/base.py
+++ b/flsim/contracts/base.py
@@ -460,6 +460,11 @@ class BaseContract:
         # (Optional) small committee reputation boost per round:
         # self.apply_committee_reputation_bonus(r)
 
+        benign = [n for n, flag in self.mal_detected[r].items() if flag == 0]
+        malicious = [n for n, flag in self.mal_detected[r].items() if flag == 1]
+        rate = len(malicious) / max(1, len(self.mal_detected[r]))
+        print(f"[Round {r}] benign={benign} malicious={malicious} detection_rate={rate:.2%}")
+
         return dict(rewards_r)
 
 

--- a/flsim/federated_aggregation/__init__.py
+++ b/flsim/federated_aggregation/__init__.py
@@ -4,10 +4,12 @@ from .aggregator import Aggregator
 from .FedAvg import Strategy as FedAvg
 from .CommitteeFedAvg import Strategy as CommitteeFedAvg
 from .trimmed_mean import Strategy as TrimmedMean
+from .flame import Strategy as FLAME
 
 __all__ = [
     "Aggregator",
     "FedAvg",
     "CommitteeFedAvg",
     "TrimmedMean",
+    "FLAME",
 ]

--- a/flsim/federated_aggregation/aggregator.py
+++ b/flsim/federated_aggregation/aggregator.py
@@ -233,12 +233,12 @@ class Aggregator:
 
         # ---------- 2) committee ----------
         try:
-            committee_ids = self.contract.set_committee(r, self.nodes)
+            # ensure contract maintains the authoritative membership list
+            self.contract.set_committee(r, self.nodes)
         except TypeError:
             fallback = self._calc_committee()
-            maybe = self.contract.set_committee(r, fallback)
-            committee_ids = maybe if isinstance(maybe, list) else fallback
-        committee_ids = set(committee_ids or [])
+            self.contract.set_committee(r, fallback)
+        committee_ids = set(self.contract.committees.get(r, []))
 
         # ---------- 3) evaluate reconstructed models ----------
         if realized_states:
@@ -258,10 +258,21 @@ class Aggregator:
 
         # ---------- 4) aggregate -> new global ----------
         meta = {"node_ids": tmp_nodes, "committee_ids": list(committee_ids)}
+        cluster_labels = {}
         if hasattr(self, "strategy") and hasattr(self.strategy, "aggregate"):
-            agg_sd = self.strategy.aggregate(realized_states, weights, base_sd=base_sd, meta=meta)
+            agg_out = self.strategy.aggregate(realized_states, weights, base_sd=base_sd, meta=meta)
+            if isinstance(agg_out, tuple):
+                agg_sd, cluster_labels = agg_out
+            else:
+                agg_sd = agg_out
         else:
             agg_sd = self.fedavg_weighted(realized_states, weights)
+
+        if cluster_labels:
+            benign = [nid for nid, lab in cluster_labels.items() if lab == 0]
+            malicious = [nid for nid, lab in cluster_labels.items() if lab != 0]
+            rate = len(malicious) / max(1, len(cluster_labels))
+            print(f"[Round {r}] benign={benign} malicious={malicious} detection_rate={rate:.2%}")
 
         new_cid = self.ipfs.save(agg_sd)
         torch.save(agg_sd, os.path.join(self.save_dir, "models", f"global_round_{r}.pt"))
@@ -304,7 +315,9 @@ class Aggregator:
             claimed = float(metrics_map.get(nid, {}).get("acc", float("nan")))
             evalacc = float(eval_accs[i]) if i < len(eval_accs) else float("nan")
             print(f"Node {nid} claimed={claimed:.4f}, eval={evalacc:.4f}, score={score:.4f}")
-            self.contract.set_features(r, nid, claimed_acc=claimed, eval_acc=evalacc)
+            # store metrics along with cluster label (default 0 if absent)
+            clabel = int(cluster_labels.get(nid, 0))
+            self.contract.set_features(r, nid, claimed_acc=claimed, eval_acc=evalacc, cluster=clabel)
 
             in_committee = (nid in committee_ids)
             rew = self._calculate_reward(node, avg_rep, in_committee) if node is not None else 0.0
@@ -312,7 +325,7 @@ class Aggregator:
             reward_map[nid] = rew
 
         # ---------- 8) settle ----------
-        self.contract.settle_round(r)
+        reward_map = self.contract.settle_round(r)
 
         print(f"[Round {r}] committee={sorted(committee_ids)} | avg_rep={avg_rep:.4f}")
         print(f"[Round {r}] contribs={contrib_map}")

--- a/flsim/federated_aggregation/flame.py
+++ b/flsim/federated_aggregation/flame.py
@@ -1,0 +1,51 @@
+from typing import Dict, List, Any, Tuple
+import torch
+import numpy as np
+from .base import AggregationStrategy, _weighted_average
+
+class Strategy(AggregationStrategy):
+    """FLAME aggregation with simple k-means clustering for anomaly detection."""
+    name = "flame"
+
+    @staticmethod
+    def _flatten_delta(sd: Dict[str, torch.Tensor]) -> np.ndarray:
+        vecs = []
+        for v in sd.values():
+            if torch.is_tensor(v):
+                vecs.append(v.detach().reshape(-1).cpu().numpy())
+        if not vecs:
+            return np.zeros(1, dtype=np.float32)
+        return np.concatenate(vecs).astype(np.float32)
+
+    @staticmethod
+    def _kmeans2(x: np.ndarray, iters: int = 10) -> np.ndarray:
+        if len(x) <= 1:
+            return np.zeros(len(x), dtype=int)
+        rng = np.random.default_rng(0)
+        centers = x[rng.choice(len(x), 2, replace=False)]
+        labels = np.zeros(len(x), dtype=int)
+        for _ in range(iters):
+            dists = ((x[:, None, :] - centers[None, :, :]) ** 2).sum(axis=2)
+            labels = dists.argmin(axis=1)
+            for j in range(2):
+                pts = x[labels == j]
+                if len(pts) > 0:
+                    centers[j] = pts.mean(axis=0)
+        return labels
+
+    def aggregate(self, states: List[Dict[str, torch.Tensor]], weights: List[float], *, base_sd: Dict[str, torch.Tensor], meta: Any) -> Tuple[Dict[str, torch.Tensor], Dict[int, int]]:
+        node_ids = meta.get("node_ids", list(range(len(states))))
+        deltas = []
+        for sd in states:
+            delta = {k: sd[k] - base_sd[k] for k in base_sd.keys()}
+            deltas.append(self._flatten_delta(delta))
+        x = np.vstack(deltas) if deltas else np.zeros((0, 1), dtype=np.float32)
+        labels = self._kmeans2(x)
+        counts = np.bincount(labels, minlength=2)
+        benign_label = int(np.argmax(counts))
+        cluster_map = {nid: int(lbl != benign_label) for nid, lbl in zip(node_ids, labels)}
+        benign_states = [sd for sd, lbl in zip(states, labels) if lbl == benign_label]
+        benign_weights = [w for w, lbl in zip(weights, labels) if lbl == benign_label]
+        agg = _weighted_average(benign_states if benign_states else states,
+                                benign_weights if benign_states else weights)
+        return agg, cluster_map


### PR DESCRIPTION
## Summary
- Add FLAME aggregation strategy that clusters client updates and filters suspicious submissions.
- Track cluster labels and print benign/malicious node lists with detection rate each round.
- Fix committee membership lookup and consolidate reward settlement to avoid double credits.
- Log detected node breakdown during round settlement.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6de52a298832f94caeb08e9482b4c